### PR TITLE
fix: tweak separated service setting bean and add tests for overrides

### DIFF
--- a/cloud-language-starter/src/main/java/com/sample/autoconfig/LanguageAutoConfig.java
+++ b/cloud-language-starter/src/main/java/com/sample/autoconfig/LanguageAutoConfig.java
@@ -96,7 +96,7 @@ public class LanguageAutoConfig {
 
   @Bean
   @ConditionalOnMissingBean(name = "languageServiceSettings")
-  public LanguageServiceSettings languageServiceClient(@Qualifier("languageServiceCredentials") CredentialsProvider credentialsProvider,
+  public LanguageServiceSettings languageServiceSettings(@Qualifier("languageServiceCredentials") CredentialsProvider credentialsProvider,
       @Qualifier("defaultLanguageTransportChannelProvider") TransportChannelProvider defaultTransportChannelProvider)
       throws IOException {
 
@@ -184,7 +184,7 @@ public class LanguageAutoConfig {
 
   @Bean
   @ConditionalOnMissingBean
-  public LanguageServiceClient languageServiceClient(@Qualifier("languageServiceSettings") LanguageServiceSettings languageServiceSettings)
+  public LanguageServiceClient languageServiceClient(LanguageServiceSettings languageServiceSettings)
       throws IOException {
     return LanguageServiceClient.create(languageServiceSettings);
   }

--- a/cloud-language-starter/src/main/java/com/sample/autoconfig/LanguageAutoConfig.java
+++ b/cloud-language-starter/src/main/java/com/sample/autoconfig/LanguageAutoConfig.java
@@ -95,7 +95,7 @@ public class LanguageAutoConfig {
   }
 
   @Bean
-  @ConditionalOnMissingBean(name = "languageServiceSettings")
+  @ConditionalOnMissingBean
   public LanguageServiceSettings languageServiceSettings(@Qualifier("languageServiceCredentials") CredentialsProvider credentialsProvider,
       @Qualifier("defaultLanguageTransportChannelProvider") TransportChannelProvider defaultTransportChannelProvider)
       throws IOException {


### PR DESCRIPTION
- Small fix to bean name typo
- Verified after that `@Qualifier("languageServiceSettings")` can be dropped 
- Added quick unit tests to check override behaviors

(Ref: [pubsub autoconfigure's TopicAdminClient and TopicAdminSettings](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/ffcd533996f667ce3fd7703c07080ee6956ce0c5/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java#L388))