### PR TITLE
poc: refactor retry settings into beans

### DIFF
--- a/cloud-language-starter/src/test/java/com/sample/autoconfig/LanguageAutoConfigTest.java
+++ b/cloud-language-starter/src/test/java/com/sample/autoconfig/LanguageAutoConfigTest.java
@@ -1,18 +1,25 @@
 package com.sample.autoconfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.auth.oauth2.UserCredentials;
 import com.google.cloud.language.v1.LanguageServiceClient;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.threeten.bp.Duration;
 
+@ExtendWith(MockitoExtension.class)
 class LanguageAutoConfigTest {
 
   private static final String SERVICE_CREDENTIAL_LOCATION = "src/test/resources/fake-credential-key.json";
@@ -27,6 +34,11 @@ class LanguageAutoConfigTest {
           .properties(
               "spring.cloud.gcp.language.language-service.enabled=true")
           .web(WebApplicationType.NONE);
+
+  @Mock
+  private RetrySettings mockAnnotateTextRetrySettings;
+  @Mock
+  private RetrySettings.Builder mockAnnotateTextRetrySettingsBuilder;
 
 
   @Test
@@ -62,5 +74,40 @@ class LanguageAutoConfigTest {
               SERVICE_CREDENTIAL_CLIENT_ID);
         });
   }
+
+    @Test
+    void defaultAnnotateTextRetrySettingsUsed() {
+        contextRunner
+                .run(
+                        ctx -> {
+                            LanguageServiceClient client = ctx.getBean(LanguageServiceClient.class);
+                            assertThat(client.getSettings().annotateTextSettings().getRetrySettings().getRetryDelayMultiplier()).isEqualTo(1.3);
+                        });
+    }
+
+    @Test
+    void customAnnotateTextRetrySettingsUsedWhenProvided() {
+      when(mockAnnotateTextRetrySettings.toBuilder()).thenReturn(mockAnnotateTextRetrySettingsBuilder);
+      when(mockAnnotateTextRetrySettingsBuilder.build()).thenReturn(mockAnnotateTextRetrySettings);
+//      when(mockAnnotateTextRetrySettings.getInitialRetryDelay()).thenReturn(Duration.ofMillis(100L));
+//      when(mockAnnotateTextRetrySettings.getMaxRetryDelay()).thenReturn(Duration.ofMillis(100L));
+//      when(mockAnnotateTextRetrySettings.getRetryDelayMultiplier()).thenReturn(2.0);
+//      when(mockAnnotateTextRetrySettings.getInitialRpcTimeout()).thenReturn(Duration.ofMillis(100L));
+//      when(mockAnnotateTextRetrySettings.getMaxRpcTimeout()).thenReturn(Duration.ofMillis(100L));
+//      when(mockAnnotateTextRetrySettings.getRpcTimeoutMultiplier()).thenReturn(2.0);
+      when(mockAnnotateTextRetrySettings.getTotalTimeout()).thenReturn(Duration.ofMillis(100L));
+
+        contextRunner
+                .withBean("annotateTextRetrySettings", RetrySettings.class, () -> mockAnnotateTextRetrySettings)
+//                .withBean("analyzeSentimentRetrySettings", RetrySettings.class, () -> mockAnalyzeSentimentRetrySettings)
+                .run(
+                        ctx -> {
+                            LanguageServiceClient client = ctx.getBean(LanguageServiceClient.class);
+                            assertThat(client.getSettings().annotateTextSettings().getRetrySettings()).isSameAs(mockAnnotateTextRetrySettings);
+                            assertThat(client.getSettings().annotateTextSettings().getRetrySettings().getTotalTimeout()).isEqualTo(Duration.ofMillis(100L));
+                            // TODO: How to achieve granularity of: if bean only overrides certain retry settings, then the others still take on client library defaults?
+                            // assertThat(client.getSettings().annotateTextSettings().getRetrySettings().getRetryDelayMultiplier()).isEqualTo(1.3);
+                        });
+    }
 
 }


### PR DESCRIPTION
Per discussion offline and in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1364

(I initially branched off the `multi-module-w-shared`, but this PR also contains the small change made to have `languageSettings` as its own bean.)
